### PR TITLE
Update to Java 21 and Weblogic 14.1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,46 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.5
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0 AS builder
 
-RUN yum -y install gettext && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+ARG ARTIFACTORY_URL
+ARG ARTIFACTORY_USERNAME
+ARG ARTIFACTORY_PASSWORD
 
 ENV EAI_HOME=/eai \
-    ARTIFACTORY_BASE_URL=https://artifactory.companieshouse.gov.uk/artifactory/virtual-release
+    ARTIFACTORY_BASE_URL=${ARTIFACTORY_URL}/virtual-release
 
-# Add an sso user and home directory
-RUN mkdir -p ${EAI_HOME} && \
-    useradd -d ${EAI_HOME} -m -s /bin/bash eai && \
-    chown eai ${EAI_HOME}
+# Add an eai user and home directory
+RUN useradd -d ${EAI_HOME} -m -s /bin/bash eai
 
 USER eai
-WORKDIR ${EAI_HOME}
 
 # Copy over scripts and properties
 COPY --chown=eai eaidaemon ${EAI_HOME}/
 
-# Download the Staffware libs and set permission on script
+# Download the Staffware libs and set permissions on scripts
 RUN mkdir -p ${EAI_HOME}/libs && \
     cd ${EAI_HOME}/libs && \
-    curl ${ARTIFACTORY_BASE_URL}/oracle/AQ/unknown/AQ-unknown.jar -o aqapi12.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/chips-aqbridge/1.104.0-rc1/chips-aqbridge-1.104.0-rc1.jar -o aqbridge.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/log4j/log4j/1.2.14/log4j-1.2.14.jar -o log4j.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/com/oracle/ojdbc8/12.2.1.4/ojdbc8-12.2.1.4.jar -o ojdbc8.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/com/oracle/weblogic/wlthint3client/12.2.1.4/wlthint3client-12.2.1.4.jar -o wlthint3client.jar && \
-    chmod 750 ${EAI_HOME}/*.sh
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/oracle/AQ/unknown/AQ-unknown.jar -o aqapi12.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/chips-aqbridge/1.104.0-rc1/chips-aqbridge-1.104.0-rc1.jar -o aqbridge.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/log4j/log4j/1.2.14/log4j-1.2.14.jar -o log4j.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/oracle/database/jdbc/ojdbc11/23.9.0.25.07/ojdbc11-23.9.0.25.07.jar -o ojdbc11.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/oracle/weblogic/wlthint3client/14.1.2.0/wlthint3client-14.1.2.0.jar -o wlthint3client.jar && \
+    chmod 500 ${EAI_HOME}/*.sh
+
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0
+
+ENV EAI_HOME=/eai
+
+# Install binaries as root
+RUN yum -y install gettext && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+# Add an eai user
+RUN useradd -d ${EAI_HOME} -m -s /bin/bash eai
+
+# Copy over the home directory from the builder
+COPY --from=builder --chown=eai ${EAI_HOME} ${EAI_HOME}/
+
+USER eai
+WORKDIR ${EAI_HOME}
 
 CMD ["bash"]

--- a/eaidaemon/eaidaemon.sh
+++ b/eaidaemon/eaidaemon.sh
@@ -7,7 +7,7 @@ timestamp() {
   done
 }
 
-export CLASSPATH=/eai:/eai/libs/aqapi12.jar:/eai/libs/aqbridge.jar:/eai/libs/ojdbc8.jar:/eai/libs/log4j.jar:/eai/libs/wlthint3client.jar
+export CLASSPATH=/eai:/eai/libs/aqapi12.jar:/eai/libs/aqbridge.jar:/eai/libs/ojdbc11.jar:/eai/libs/log4j.jar:/eai/libs/wlthint3client.jar
 
 # Set the vars in the jndi.properties and jms.properties files
 envsubst < jndi.properties.template > jndi.properties
@@ -19,7 +19,7 @@ LOG_FILE="${LOGS_DIR}/${HOSTNAME}-eaidaemon-$(date +'%Y-%m-%d_%H-%M-%S').log"
 
 while :
 do
-  /usr/java/jdk-8/bin/java -d64 -classpath $CLASSPATH uk.gov.ch.chips.server.aqbridge.StaffwareEAIBridge
+  /usr/java/jdk/bin/java -classpath $CLASSPATH uk.gov.ch.chips.server.aqbridge.StaffwareEAIBridge
 
   echo "========================="
   echo "EAI Daemon Exited >>>  on ${HOST_SERVER} "


### PR DESCRIPTION
Updates the chips-staffware-eai build to:
- use Java 21/Oracle linux 8 base image
- reference WL14 libraries and matching JDBC version
- download the dependencies from the new authenticated artifactory server

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-935